### PR TITLE
Compare products functionality

### DIFF
--- a/app/code/community/FireGento/PerformanceTweaks/Model/Log/Visitor.php
+++ b/app/code/community/FireGento/PerformanceTweaks/Model/Log/Visitor.php
@@ -1,0 +1,36 @@
+<?php
+
+
+/**
+ * FireGento_PerformanceTweaks_Model_Log_Visitor
+ *
+ * @category FireGento
+ * @package  FireGento_PerformanceTweaks
+ * @author   Thomas Hampe <github@hampe.co>
+ * @license  http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
+ */
+class FireGento_PerformanceTweaks_Model_Log_Visitor extends Mage_Log_Model_Visitor
+{
+
+    /**
+     * Returns a "fake" visitor id for product compare
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        if (!$this->getData('visitor_id')) {
+            /** @var FireGento_PerformanceTweaks_Model_Session $session */
+            $session = Mage::getModel('firegento_performancetweaks/session');
+            $this->setId($session->getVisitorId());
+        }
+        return parent::getId();
+    }
+
+    public function getVisitorId()
+    {
+        return $this->getId();
+    }
+
+
+}

--- a/app/code/community/FireGento/PerformanceTweaks/Model/Session.php
+++ b/app/code/community/FireGento/PerformanceTweaks/Model/Session.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomas
+ * Date: 05.03.17
+ * Time: 10:49
+ */
+
+/**
+ * FireGento_PerformanceTweaks_Model_Session
+ *
+ * @category FireGento
+ * @package  FireGento_PerformanceTweaks
+ * @author   Thomas Hampe <github@hampe.co>
+ * @license  http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
+ */
+class FireGento_PerformanceTweaks_Model_Session extends Mage_Core_Model_Session_Abstract
+{
+
+
+    public function __construct()
+    {
+        $this->init('firegento_performancetweaks');
+    }
+
+    public function getVisitorId()
+    {
+        if (!$this->hasData('visitor_id')) {
+            $this->setData('visitor_id', $this->_generateVisitorId());
+        }
+        return $this->getData('visitor_id');
+    }
+
+    protected function _generateVisitorId()
+    {
+        return $this->getSessionId() ? crc32($this->getSessionId()) : null;
+    }
+
+}

--- a/app/code/community/FireGento/PerformanceTweaks/etc/config.xml
+++ b/app/code/community/FireGento/PerformanceTweaks/etc/config.xml
@@ -25,6 +25,11 @@
           <product_type_configurable_product_collection>FireGento_PerformanceTweaks_Model_Catalog_Resource_Product_Type_Configurable_Product_Collection</product_type_configurable_product_collection>
         </rewrite>
       </catalog_resource>
+      <log>
+          <rewrite>
+              <visitor>FireGento_PerformanceTweaks_Model_Log_Visitor</visitor>
+          </rewrite>
+      </log>
       <eav>
         <rewrite>
           <entity_attribute_source_table>FireGento_PerformanceTweaks_Model_Eav_Entity_Attribute_Source_Table</entity_attribute_source_table>


### PR DESCRIPTION
Hi,

thanks for making this awesome extension. The only real drawback I could find, was the no longer working product function. 
So this PR provides a working product compare functionality. It uses a _fake_ / generated `visitor_id` based on the current `session_id`. The `visitor_id` is saved in a session variable, so it is still available after a customer login (which renews the `session_id`).

If you have any questions feel free to ask them.